### PR TITLE
Exception thrown on pages where body's first child is a TextNode

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -213,7 +213,7 @@
     // First, check if it's a PRE and exit if not
       var bodyChildren = document.body.childNodes ;
       pre = bodyChildren[0] ;
-      var jsonLength = pre.innerText.length ;
+      var jsonLength = (pre.innerText || "").length ;
       if (
         bodyChildren.length !== 1 ||
         pre.tagName !== 'PRE' ||


### PR DESCRIPTION
On a (non-JSON) page where the body's first child is a child node, a `TypeError: Cannot read property 'length' of undefined` exception is thrown since the node has no `innerText` property.
