### PR TITLE
add check for when document.body has no children

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -213,7 +213,7 @@
     // First, check if it's a PRE and exit if not
       var bodyChildren = document.body.childNodes ;
       pre = bodyChildren[0] ;
-      var jsonLength = (pre.innerText || "").length ;
+      var jsonLength = (pre && pre.innerText || "").length ;
       if (
         bodyChildren.length !== 1 ||
         pre.tagName !== 'PRE' ||


### PR DESCRIPTION
in pages that return empty (and not about:blank), this extension keeps erroring on checking pre.innerText.
