### PR TITLE
Stop double-encoding/decoding an already-json string

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -195,7 +195,7 @@
           // Export parsed JSON for easy access in console
             setTimeout(function () {
               var script = document.createElement("script") ;
-              script.innerHTML = 'window.json = ' + JSON.parse(JSON.stringify(msg[2])) + ';' ;
+              script.innerHTML = 'window.json = ' + msg[2] + ';' ;
               document.head.appendChild(script) ;
               console.log('JSON Formatter: Type "json" to inspect.') ;
             }, 100) ;


### PR DESCRIPTION
`msg[2]` already is a JSON-serialized string here; no need to quote and unquote it a second pass
