### PR TITLE
Chromium 29 reports errors trying to reference chrome.extension

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -34,7 +34,7 @@
 /*global chrome, console */
 
 (function () {
-  
+
   "use strict" ;
 
   // Constants
@@ -151,7 +151,7 @@
   // Template elements
     var templates,
         baseSpan = document.createElement('span') ;
-    
+
     function getSpanBoth(innerText,className) {
       var span = baseSpan.cloneNode(false) ;
       span.className = className ;
@@ -176,19 +176,19 @@
         t_key: getSpanClass('k'),
         t_string: getSpanClass('s'),
         t_number: getSpanClass('n'),
-        
+
         t_null: getSpanBoth('null', 'nl'),
         t_true: getSpanBoth('true','bl'),
         t_false: getSpanBoth('false','bl'),
-        
+
         t_oBrace: getSpanBoth('{','b'),
         t_cBrace: getSpanBoth('}','b'),
         t_oBracket: getSpanBoth('[','b'),
         t_cBracket: getSpanBoth(']','b'),
-        
+
         t_ellipsis: getSpanClass('ell'),
         t_blockInner: getSpanClass('blockInner'),
-        
+
         t_colonAndSpace: document.createTextNode(':\u00A0'),
         t_commaText: document.createTextNode(','),
         t_dblqText: document.createTextNode('"')
@@ -221,7 +221,7 @@
 
       // Root node for this kvov
         kvov = templates.t_kvov.cloneNode(false) ;
-      
+
       // Add an 'expander' first (if this is object/array with non-zero size)
         if (type === TYPE_OBJECT || type === TYPE_ARRAY) {
           nonZeroSize = false ;
@@ -234,7 +234,7 @@
           if (nonZeroSize)
             kvov.appendChild(  templates.t_exp.cloneNode(false) ) ;
         }
-        
+
       // If there's a key, add that before the value
         if (keyName !== false) { // NB: "" is a legal keyname in JSON
           // This kvov must be an object property
@@ -253,7 +253,7 @@
           // This is an array element instead
             kvov.classList.add('arrElem') ;
         }
-      
+
       // Generate DOM for this value
         var blockInner, childKvov ;
         switch (type) {
@@ -278,14 +278,14 @@
               valueElement.appendChild(templates.t_dblqText.cloneNode(false)) ;
               kvov.appendChild(valueElement) ;
             break ;
-          
+
           case TYPE_NUMBER:
             // Simply add a number element (span.n)
               valueElement = templates.t_number.cloneNode(false) ;
               valueElement.innerText = value ;
               kvov.appendChild(valueElement) ;
             break ;
-          
+
           case TYPE_OBJECT:
             // Add opening brace
               kvov.appendChild( templates.t_oBrace.cloneNode(true) ) ;
@@ -312,7 +312,7 @@
                 // Add blockInner
                   kvov.appendChild( blockInner ) ;
               }
-            
+
             // Add closing brace
               kvov.appendChild( templates.t_cBrace.cloneNode(true) ) ;
             break ;
@@ -357,7 +357,7 @@
 
       return kvov ;
     }
-  
+
 
 
 
@@ -373,15 +373,15 @@
 
       // Set class on root node to identify it
         rootKvov.classList.add('rootKvov') ;
-        
+
       // Make div#formattedJson and append the root kvov
         var divFormattedJson = document.createElement('DIV') ;
         divFormattedJson.id = 'formattedJson' ;
         divFormattedJson.appendChild( rootKvov ) ;
-      
+
       // Convert it to an HTML string (shame about this step, but necessary for passing it through to the content page)
         var returnHTML = divFormattedJson.outerHTML ;
-        
+
       // Top and tail with JSONP padding if necessary
         if (jsonpFunctionName !== null) {
           returnHTML =
@@ -395,7 +395,7 @@
     }
 
   // Listen for requests from content pages wanting to set up a port
-    chrome.extension.onConnect.addListener(function(port) {
+    chrome.runtime.onConnect.addListener(function(port) {
 
       if (port.name !== 'jf') {
         console.log('JSON Formatter error - unknown port name '+port.name, port) ;
@@ -431,7 +431,7 @@
                     port.disconnect() ;
                     return ;
                   }
-                
+
                 // Get the substring up to the first "(", with any comments/whitespace stripped out
                   var firstBit = removeComments( text.substring(0,indexOfParen) ).trim() ;
                   if ( ! firstBit.match(/^[a-zA-Z_$][\.\[\]'"0-9a-zA-Z_$]*$/) ) {
@@ -440,7 +440,7 @@
                     port.disconnect() ;
                     return ;
                   }
-                
+
                 // Find last parenthesis (exit if none)
                   var indexOfLastParen ;
                   if ( ! (indexOfLastParen = text.lastIndexOf(')') ) ) {
@@ -448,7 +448,7 @@
                     port.disconnect() ;
                     return ;
                   }
-                
+
                 // Check that what's after the last parenthesis is just whitespace, comments, and possibly a semicolon (exit if anything else)
                   var lastBit = removeComments(text.substring(indexOfLastParen+1)).trim() ;
                   if ( lastBit !== "" && lastBit !== ';' ) {
@@ -456,7 +456,7 @@
                     port.disconnect() ;
                     return ;
                   }
-                  
+
                 // So, it looks like a valid JS function call, but we don't know whether it's JSON inside the parentheses...
                 // Check if the 'argument' is actually JSON (and record the parsed result)
                   text = text.substring(indexOfParen+1, indexOfLastParen) ;
@@ -470,7 +470,7 @@
                       port.postMessage(['NOT JSON', 'looks like a function call, but the parameter is not valid JSON']) ;
                       return ;
                   }
-                  
+
               jsonpFunctionName = firstBit ;
             }
 

--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -48,15 +48,15 @@
       exitedNotJsonTime,
       displayedFormattedJsonTime
   ;
-  
+
   // Open the port "jf" now, ready for when we need it
     // console.time('established port') ;
-    port = chrome.extension.connect({name: 'jf'}) ;
-    
+    port = chrome.runtime.connect({name: 'jf'}) ;
+
   // Add listener to receive response from BG when ready
     port.onMessage.addListener( function (msg) {
       // console.log('Port msg received', msg[0], (""+msg[1]).substring(0,30)) ;
-      
+
       switch (msg[0]) {
         case 'NOT JSON' :
           pre.hidden = false ;
@@ -64,7 +64,7 @@
           document.body.removeChild(jfContent) ;
           exitedNotJsonTime = +(new Date()) ;
           break ;
-          
+
         case 'FORMATTING' :
           isJsonTime = +(new Date()) ;
 
@@ -72,7 +72,7 @@
 
           // Clear the slowAnalysisTimeout (if the BG worker had taken longer than 1s to respond with an answer to whether or not this is JSON, then it would have fired, unhiding the PRE... But now that we know it's JSON, we can clear this timeout, ensuring the PRE stays hidden.)
             clearTimeout(slowAnalysisTimeout) ;
-          
+
           // Insert CSS
             jfStyleEl = document.createElement('style') ;
             jfStyleEl.id = 'jfStyleEl' ;
@@ -83,7 +83,7 @@
               'beforeend',
               'body{-webkit-user-select:text;overflow-y:scroll !important;margin:0;position:relative}#optionBar{-webkit-user-select:none;display:block;position:absolute;top:9px;right:17px}#buttonFormatted,#buttonPlain{-webkit-border-radius:2px;-webkit-box-shadow:0px 1px 3px rgba(0,0,0,0.1);-webkit-user-select:none;background:-webkit-linear-gradient(#fafafa, #f4f4f4 40%, #e5e5e5);border:1px solid #aaa;color:#444;font-size:12px;margin-bottom:0px;min-width:4em;padding:3px 0;position:relative;z-index:10;display:inline-block;width:80px;text-shadow:1px 1px rgba(255,255,255,0.3)}#buttonFormatted{margin-left:0;border-top-left-radius:0;border-bottom-left-radius:0}#buttonPlain{margin-right:0;border-top-right-radius:0;border-bottom-right-radius:0;border-right:none}#buttonFormatted:hover,#buttonPlain:hover{-webkit-box-shadow:0px 1px 3px rgba(0,0,0,0.2);background:#ebebeb -webkit-linear-gradient(#fefefe, #f8f8f8 40%, #e9e9e9);border-color:#999;color:#222}#buttonFormatted:active,#buttonPlain:active{-webkit-box-shadow:inset 0px 1px 3px rgba(0,0,0,0.2);background:#ebebeb -webkit-linear-gradient(#f4f4f4, #efefef 40%, #dcdcdc);color:#333}#buttonFormatted.selected,#buttonPlain.selected{-webkit-box-shadow:inset 0px 1px 5px rgba(0,0,0,0.2);background:#ebebeb -webkit-linear-gradient(#e4e4e4, #dfdfdf 40%, #dcdcdc);color:#333}#jsonpOpener,#jsonpCloser{padding:4px 0 0 8px;color:black;margin-bottom:-6px}#jsonpCloser{margin-top:0}#formattedJson{padding-left:28px;padding-top:6px}pre{padding:36px 5px 5px 5px}.kvov{display:block;padding-left:20px;margin-left:-20px;position:relative}.collapsed{white-space:nowrap}.collapsed>.blockInner{display:none}.collapsed>.ell:after{content:"…";font-weight:bold}.collapsed>.ell{margin:0 4px;color:#888}.collapsed .kvov{display:inline}.e{width:20px;height:18px;display:block;position:absolute;left:-2px;top:1px;z-index:5;background-image:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAD1JREFUeNpiYGBgOADE%2F3Hgw0DM4IRHgSsDFOzFInmMAQnY49ONzZRjDFiADT7dMLALiE8y4AGW6LoBAgwAuIkf%2F%2FB7O9sAAAAASUVORK5CYII%3D");background-repeat:no-repeat;background-position:center center;display:block;opacity:0.15}.collapsed>.e{-webkit-transform:rotate(-90deg);width:18px;height:20px;left:0px;top:0px}.e:hover{opacity:0.35}.e:active{opacity:0.5}.collapsed .kvov .e{display:none}.blockInner{display:block;padding-left:24px;border-left:1px dotted #bbb;margin-left:2px}#formattedJson,#jsonpOpener,#jsonpCloser{color:#333;font:13px/18px monospace}#formattedJson{color:#444}.b{font-weight:bold}.s{color:#0B7500;word-wrap:break-word}a:link,a:visited{text-decoration:none;color:inherit}a:hover,a:active{text-decoration:underline;color:#050}.bl,.nl,.n{font-weight:bold;color:#1A01CC}.k{color:black}#formattingMsg{font:13px "Lucida Grande", "Segoe UI", "Tahoma";padding:10px 0 0 8px;margin:0;color:#333}#formattingMsg>svg{margin:0 7px;position:relative;top:1px}[hidden]{display:none !important}span{white-space:pre-wrap}@-webkit-keyframes spin{from{-webkit-transform:rotate(0deg)}to{-webkit-transform:rotate(360deg)}}#spinner{-webkit-animation:spin 2s 0 infinite}*{-webkit-font-smoothing:antialiased}'
             ) ;
-  
+
             // Add custom font name if set - FROM FUTURE
               // if (typeof settings.fontName === 'string') {
               //   jfStyleEl.insertAdjacentHTML(
@@ -104,13 +104,13 @@
             setTimeout(function(){
               formattingMsg.hidden = false ;
             }, 250) ;
-          
-          
+
+
           // Create option bar
             var optionBar = document.createElement('div') ;
             optionBar.id = 'optionBar' ;
-          
-          
+
+
           // Show options link, if needed - FROM FUTURE
             // if (settings.enableOptionsLink) {
             //   var optionsLink = document.createElement('a') ;
@@ -120,7 +120,7 @@
             //   optionsLink.target = '_BLANK' ;
             //   optionBar.appendChild(optionsLink) ;
             // }
-          
+
           // Create toggleFormat button
             var buttonPlain = document.createElement('button'),
               buttonFormatted = document.createElement('button') ;
@@ -129,7 +129,7 @@
             buttonFormatted.id = 'buttonFormatted' ;
             buttonFormatted.innerText = 'Parsed' ;
             buttonFormatted.classList.add('selected') ;
-            
+
             var plainOn = false ;
             buttonPlain.addEventListener(
               'click',
@@ -146,7 +146,7 @@
               },
               false
             ) ;
-            
+
             buttonFormatted.addEventListener(
               'click',
               function () {
@@ -162,7 +162,7 @@
               },
               false
             ) ;
-            
+
             // Put it in optionBar
               optionBar.appendChild(buttonPlain) ;
               optionBar.appendChild(buttonFormatted) ;
@@ -173,16 +173,16 @@
               generalClick,
               false // No need to propogate down
             ) ;
-          
+
           // Put option bar in DOM
             document.body.insertBefore(optionBar, pre) ;
 
           break ;
-            
+
         case 'FORMATTED' :
           // Insert HTML content
             jfContent.innerHTML = msg[1] ;
-          
+
           displayedFormattedJsonTime = Date.now() ;
 
           // Log times
@@ -201,19 +201,19 @@
             }, 100) ;
 
           break ;
-        
+
         default :
           throw new Error('Message not understood: ' + msg[0]) ;
       }
     });
-  
+
     // console.timeEnd('established port') ;
 
 
   function ready () {
-    
+
     domReadyTime = Date.now() ;
-      
+
     // First, check if it's a PRE and exit if not
       var bodyChildren = document.body.childNodes ;
       pre = bodyChildren[0] ;
@@ -228,20 +228,20 @@
 
         // Disconnect the port (without even having used it)
           port.disconnect() ;
-        
+
         // EXIT POINT: NON-PLAIN-TEXT PAGE (or longer than 3MB)
       }
       else {
         // This is a 'plain text' page (just a body with one PRE child).
         // It might be JSON/JSONP, or just some other kind of plain text (eg CSS).
-        
+
         // Hide the PRE immediately (until we know what to do, to prevent FOUC)
           pre.hidden = true ;
           //console.log('It is text; hidden pre at ') ;
           slowAnalysisTimeout = setTimeout(function(){
             pre.hidden = false ;
           }, 1000) ;
-        
+
         // Send the contents of the PRE to the BG script
           // Add jfContent DIV, ready to display stuff
             jfContent = document.createElement('div') ;
@@ -254,11 +254,11 @@
               text: pre.innerText,
               length: jsonLength
             });
-        
+
           // Now, this script will just wait to receive anything back via another port message. The returned message will be something like "NOT JSON" or "IS JSON"
       }
   }
-  
+
   document.addEventListener("DOMContentLoaded", ready, false);
 
   var lastKvovIdGiven = 0 ;
@@ -319,7 +319,7 @@
 
     if (ev.which === 1) {
       var elem = ev.target ;
-      
+
       if (elem.className === 'e') {
         // It's a click on an expander.
 
@@ -331,7 +331,7 @@
             scrollTop = document.body.scrollTop,
             parentSiblings
         ;
-        
+
         // Expand or collapse
           if (parent.classList.contains('collapsed')) {
             // EXPAND
@@ -365,10 +365,10 @@
             }
 
           // console.log('Scrolltop HAS changed. document.body.scrollTop is now '+document.body.scrollTop+'; was '+scrollTop) ;
-          
+
           // The body has got a bit shorter.
           // We need to increase the body height by a bit (by increasing the bottom margin on the jfContent div). The amount to increase it is whatever is the difference between our previous scrollTop and our new one.
-          
+
           // Work out how much more our target scrollTop is than this.
             var difference = scrollTop - document.body.scrollTop  + 8 ; // it always loses 8px; don't know why
 
@@ -378,7 +378,7 @@
 
           // Now change the scrollTop back to what it was
             document.body.scrollTop = scrollTop ;
-            
+
         return ;
       }
     }


### PR DESCRIPTION
On Chromium 29 / Ubuntu I see the following

```
chrome.extension is not available: 'extension' is not allowed for specified context type content script,  extension page, web page, etc.). [VM] binding (409):427
Binding.generate [VM] binding (409):427
(anonymous function) extension:114
(anonymous function) chrome-extension://bcjindcccaagfpapjjmafapmmgkkhgoa/js/content.js:54
(anonymous function) chrome-extension://bcjindcccaagfpapjjmafapmmgkkhgoa/js/content.js:387
Uncaught TypeError: Cannot call method 'connect' of undefined chrome-extension://bcjindcccaagfpapjjmafapmmgkkhgoa/js/content.js:54
(anonymous function) chrome-extension://bcjindcccaagfpapjjmafapmmgkkhgoa/js/content.js:54
(anonymous function) chrome-extension://bcjindcccaagfpapjjmafapmmgkkhgoa/js/content.js:387
```

This used to work on earlier versions of chromium, but maybe the method was deprecated, and they finally removed it. See here for context: https://code.google.com/p/chromium/issues/detail?id=289776#c1

Sorry: there are only two code lines that changed, but for some reason there's some whitespace changes too
