### PR TITLE
Render a string as a link if the keyName is `url` or `href`

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -137,6 +137,13 @@
       return idx ;
     }
 
+    /* This function gets called for every string value in the object, so it needs to be
+     * super-speedy. A good regex would be more accurate but would probably be much
+     * slower too. Matching on the value starting with `http` is crude but fast — some
+     * false positives, but rare, and the UX doesn't suffer terribly from them.
+     * If the key is named `url` or `href` we assume that the value is a URL — this is
+     * useful for relative URLs.
+     */
     function isURL(keyName, value) {
       return ((value[0] === 'h' && value.substring(0, 4) === 'http')
               || keyName === 'url'

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -137,6 +137,12 @@
       return idx ;
     }
 
+    function isURL(keyName, value) {
+      return ((value[0] === 'h' && value.substring(0, 4) === 'http')
+              || (keyName[0] === 'u' && keyName === 'url')
+              || (keyName[0] === 'h' && keyName === 'href'));
+    }
+
     // function spin(seconds) {
     //   // spin - Hog the CPU for the specified number of seconds
     //   // (for simulating long processing times in development)
@@ -263,7 +269,8 @@
                   escapedString = JSON.stringify(value)
               ;
               escapedString = escapedString.substring(1, escapedString.length-1) ; // remove quotes
-              if (value[0] === 'h' && value.substring(0, 4) === 'http') { // crude but fast - some false positives, but rare, and UX doesn't suffer terribly from them.
+
+              if (isURL(keyName, value)) {
                 var innerStringA = document.createElement('A') ;
                 innerStringA.href = value ;
                 innerStringA.innerText = escapedString ;

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -139,8 +139,8 @@
 
     function isURL(keyName, value) {
       return ((value[0] === 'h' && value.substring(0, 4) === 'http')
-              || (keyName[0] === 'u' && keyName === 'url')
-              || (keyName[0] === 'h' && keyName === 'href'));
+              || keyName === 'url'
+              || keyName === 'href');
     }
 
     // function spin(seconds) {


### PR DESCRIPTION
This is useful when an API uses relative URLs — this way if the keys are named sensibly then they’ll be rendered as links.