### PR TITLE
Focused button

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -142,6 +142,7 @@
 
                   buttonFormatted.classList.remove('selected') ;
                   buttonPlain.classList.add('selected') ;
+                  buttonPlain.blur() ;
                 }
               },
               false
@@ -158,6 +159,7 @@
 
                   buttonFormatted.classList.add('selected') ;
                   buttonPlain.classList.remove('selected') ;
+                  buttonFormatted.blur() ;
                 }
               },
               false


### PR DESCRIPTION
When buttonPlain or buttonFormatted is clicked it keeps focused until you click somewhere else. 
Added .blur() on the click functions to solve this behavior.
