### PR TITLE
Strip out Express typeof check from JSONP

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -121,6 +121,10 @@
       return str.join('').slice(2, -2);
     }
 
+    function removeTypeofGuard(s) {
+      return s.replace(/^typeof \S+ === 'function' && /, '');
+    }
+
     function firstJSONCharIndex(s) {
       var arrayIdx = s.indexOf('['),
           objIdx = s.indexOf('{'),
@@ -434,6 +438,7 @@
                 
                 // Get the substring up to the first "(", with any comments/whitespace stripped out
                   var firstBit = removeComments( text.substring(0,indexOfParen) ).trim() ;
+                  firstBit = removeTypeofGuard(firstBit);
                   if ( ! firstBit.match(/^[a-zA-Z_$][\.\[\]'"0-9a-zA-Z_$]*$/) ) {
                     // The 'firstBit' is NOT a valid function identifier.
                     port.postMessage(['NOT JSON', 'first bit not a valid function name']) ;


### PR DESCRIPTION
Express server adds a 'typeof' check to JSONP responses to reduce client error noise (and an empty comment for security). See:
https://github.com/strongloop/express/blob/4.13.3/lib/response.js#L312-L314

Example output:
http://ibl.api.bbci.co.uk/?callback=notReal

The extension does not currently recognise such output as JSONP. This pull request fixes that by stripping out the 'typeof' check before checking whether the response is valid. It closes #49.