### PR TITLE
Add Alert for JSON Files Larger than 3MB

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -222,7 +222,7 @@
         bodyChildren.length !== 1 ||
         pre.tagName !== 'PRE' ||
         jsonLength > (3000000) ) {
-
+          alert('Cannot format JSON: Text is not even or longer than 3MB.')
         // console.log('Not even text (or longer than 3MB); exiting') ;
         // console.log(bodyChildren.length,pre.tagName, pre.innerText.length) ;
 

--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -220,9 +220,7 @@
       var jsonLength = (pre && pre.innerText || "").length ;
       if (
         bodyChildren.length !== 1 ||
-        pre.tagName !== 'PRE' ||
-        jsonLength > (3000000) ) {
-          alert('Cannot format JSON: Text is not even or longer than 3MB.')
+        pre.tagName !== 'PRE') {
         // console.log('Not even text (or longer than 3MB); exiting') ;
         // console.log(bodyChildren.length,pre.tagName, pre.innerText.length) ;
 
@@ -230,6 +228,10 @@
           port.disconnect() ;
         
         // EXIT POINT: NON-PLAIN-TEXT PAGE (or longer than 3MB)
+      }
+      else if (jsonLength > (300000)) {
+        alert('JSON Formatter Error: Cannot format JSON longer than 3MB')
+        port.disconnect();
       }
       else {
         // This is a 'plain text' page (just a body with one PRE child).


### PR DESCRIPTION
This PR addresses Issue #22 

* My approach for this iteration was to add an alert for large JSON files. This would be good feedback for the user when trying to parse JSON.
```js
 else if (jsonLength > (300000)) {
        alert('JSON Formatter Error: Cannot format JSON longer than 3MB')
        port.disconnect();
      }
```
* Since issue #67 included a possible solution for parsing large JSON files, this may be included in the next iteration