### PR TITLE
Update ReadMe With Working Test Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Installation
 
 **Some URLs to try it on:**
 
-* http://feeds.delicious.com/v2/json/popular?callback=hello
-* http://gdata.youtube.com/feeds/api/standardfeeds/most_popular?alt=json&v=2
-* http://twitter.com/statuses/public_timeline.json
+* http://date.jsontest.com/
+* https://api.github.com/users/callumlocke/repos
+* https://www.thecocktaildb.com/api/json/v1/1/search.php?s=margarita
 
 FAQ
 ---


### PR DESCRIPTION
Of the three links available to test the extension, none are still available APIs. I have replaced them with three JSON endpoints that I found by searching for good examples.