### PR TITLE
#211: Extension conflicts with LastPass 4.101.1

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -233,7 +233,7 @@
       pre = bodyChildren[0] ;
       var jsonLength = (pre && pre.innerText || "").length ;
       if (
-        bodyChildren.length !== 1 ||
+        bodyChildren.length > 2 ||
         pre.tagName !== 'PRE' ||
         jsonLength > (3000000) ) {
 


### PR DESCRIPTION
In August 2022, an update to Chrome changed the body for JSON content, adding an extra `<div>` element and breaking the extension's assumption that JSON documents will only have a single `<pre>` child within the document's body.

This PR includes a simple fix: aborting when there are more than two children under body instead of assuming there will be one. Allowing for one or two children under body allows the extension to continue working for older versions of Chrome.