### PR TITLE
Adding button to inject window.json value

### DIFF
--- a/src/content.entry.ts
+++ b/src/content.entry.ts
@@ -178,6 +178,13 @@ const resultPromise = (async (): Promise<{
       optionBar.appendChild(buttonPlain)
       optionBar.appendChild(buttonFormatted)
 
+      const buttonInject = document.createElement('button')
+      buttonInject.innerText = 'Inject window.json'
+      buttonInject.setAttribute('onclick', `window.json = JSON.parse(document.getElementById("jsonFormatterRaw").querySelector("pre").innerText)`)
+      buttonInject.setAttribute('style', 'display: block; width: 100%; border-right: 1px solid #aaa;')
+      buttonInject.id = "buttonPlain"
+      optionBar.appendChild(buttonInject)
+  
       document.body.prepend(optionBar)
 
       // Attach document-wide listener


### PR DESCRIPTION
This PR add's a button to the option bar that adds the value of the JSON to the global variable `window.json` as per the docs approach: 

`json = JSON.parse(document.getElementById("jsonFormatterRaw").querySelector("pre").innerText)`

Attempted resolve of #231 

Related unresolved PR:
https://github.com/callumlocke/json-formatter/pull/242

Inspiration
https://github.com/callumlocke/json-formatter/issues/231#issuecomment-1521730777

![image](https://github.com/callumlocke/json-formatter/assets/22232800/bd0ef571-d726-4271-b6ca-1e73a51908f9)


