### PR TITLE
Remove the new pretty-print bar

### DIFF
--- a/src/content.entry.ts
+++ b/src/content.entry.ts
@@ -195,6 +195,13 @@ const resultPromise = (async (): Promise<{
     // console.log('JSON Formatter: Type "json" to inspect.')
   }
 
+  // remove the pretty-print bar
+  for (const el of document.getElementsByClassName(
+    'json-formatter-container'
+  )) {
+    el.style.display = 'none'
+  }
+
   return {
     formatted: true,
     note: 'done',


### PR DESCRIPTION
In newer versions of at least Chrome, a pretty-print bar appeared:
![Pretty-print with checkbox](https://github.com/callumlocke/json-formatter/assets/93737747/8fb4126f-c4d1-46be-af01-3cf620929ebd)

This  doesn't work and is redundant when using this extension. This PR hides all elements with the class `json-formatter-container` which is the one used in Google Chrome.

Resolves #266 