### PR TITLE
Add copy button for strings

### DIFF
--- a/src/lib/buildDom.ts
+++ b/src/lib/buildDom.ts
@@ -105,11 +105,17 @@ export const buildDom = (
       } else {
         innerStringEl.innerText = escapedString
       }
+
+      const copyBtn = document.createElement("button")
+      copyBtn.textContent = "Copy";
+      copyBtn.addEventListener("click", () => { navigator.clipboard.writeText(value) })
+
       const valueElement = templates.t_string.cloneNode(false)
       valueElement.appendChild(templates.t_dblqText.cloneNode(false))
       valueElement.appendChild(innerStringEl)
       valueElement.appendChild(templates.t_dblqText.cloneNode(false))
       entry.appendChild(valueElement)
+      entry.appendChild(copyBtn)
       break
     }
 


### PR DESCRIPTION
Add's a copy button for strings.

Can potentially add to other data types or make into a common function, but since all of the other data types are relatively easy to copy and paste (double click) I figured I'd only add to strings for now.,

Strings can have `-` or `_` making them unable to double click and get the whole string to copy and paste.

I was not able to get the local dev setup to match the live one, mine had much different formatting so please let me know how to fix this.

<img width="1728" alt="image" src="https://github.com/callumlocke/json-formatter/assets/13057262/89ffd17b-726c-4627-b0ee-20103bcb1310">
